### PR TITLE
before actions added for update in fish and lures controllers

### DIFF
--- a/app/controllers/fish_controller.rb
+++ b/app/controllers/fish_controller.rb
@@ -1,4 +1,6 @@
 class FishController < ApplicationController
+    before_action :find_fish_by_id, only:[:show, :update]
+
     def index
         @fish = Fish.all
         render json: @fish
@@ -9,12 +11,16 @@ class FishController < ApplicationController
     end
     
     def update
-        @fish = Fish.update(fish_params)
+        @fish.update(fish_params)
         render json: @fish
     end
-    
+
     private
     def fish_params
-        params.require(:fish).permit(:species, :description, :caught, :image, :pr, :id )
+        params.require(:fish).permit(:species, :description, :caught, :image, :pr)
+    end
+
+    def find_fish_by_id
+        @fish = Fish.find(params[:id])
     end
 end

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -5,8 +5,7 @@ class LocationsController < ApplicationController
     end
 
     def show
-        @location = Location.find(params[:id])
-        render json: @location
+        render json: @fish
     end
 
     def create

--- a/app/controllers/lures_controller.rb
+++ b/app/controllers/lures_controller.rb
@@ -1,4 +1,5 @@
 class LuresController < ApplicationController
+    before_action :find_lure_by_id, only:[:show, :update]
 
     def index
         @lures = Lure.all
@@ -6,7 +7,6 @@ class LuresController < ApplicationController
     end
 
     def show
-        @lure = Lure.find(params[:id])
         render json: @lure
     end
 
@@ -16,12 +16,16 @@ class LuresController < ApplicationController
     end
 
     def update
-        @lure = Lure.update(lure_params)
+        @lure.update(lure_params)
         render json: @lure
     end
 
     private
     def lure_params
-        params.require(:lure).permit(:name, :brand, :lureType, :size, :image, :color, :favorited, :id )
+        params.require(:lure).permit(:name, :brand, :lureType, :size, :image, :color, :favorited )
+    end
+
+    def find_lure_by_id
+        @lure = Lure.find(params[:id])
     end
 end


### PR DESCRIPTION
these before actions allow the user's changes (adding to tacklebox and adding to caught list) to properly persist on the backend. prior to this only the first lure/fish added would stay in their position after refreshing.